### PR TITLE
deps: batch dependency updates (2026-05)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,9 +5314,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-memstore"
-version = "0.10.0-alpha.18"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1088bc9ae135e392594f67a072588baa47df9959034a47f0efdff997cd833bb"
+checksum = "d9f2f4981afe12e56a7b180f4a0a1b50bee99ce280d4dcc97240c3607f5710e3"
 dependencies = [
  "derive_more 2.1.1",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4181,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -4200,6 +4200,7 @@ dependencies = [
  "sha2 0.10.9",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8728,9 +8728,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5654,9 +5654,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d7efd3052f7d6ef601085559a246bc991e9a8cc77e02753737df6322ce35f1"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4036,16 +4036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8774,9 +8764,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -8787,7 +8777,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -8798,6 +8787,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5354,9 +5354,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -5394,9 +5394,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4487,9 +4487,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5190,6 +5190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-system-configuration"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8085,15 +8096,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows 0.62.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,9 +903,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523ab528ce3a7ada6597f8ccf5bd8d85ebe26d5edf311cad4d1d3cfb2d357ac6"
+checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
 dependencies = [
  "base64 0.22.1",
  "blowfish",
@@ -1068,12 +1068,12 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
 dependencies = [
  "byteorder",
- "cipher 0.4.4",
+ "cipher 0.5.1",
 ]
 
 [[package]]

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -135,7 +135,7 @@ tantivy = "0.26"
 
 # Openraft (replication)
 openraft = { version = "=0.10.0-alpha.20", features = ["serde", "type-alias"] }
-openraft-memstore = "=0.10.0-alpha.18"
+openraft-memstore = "=0.10.0-alpha.20"
 
 # Prometheus / OTel
 prometheus = "0.14"

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -112,7 +112,7 @@ reqwest = { version = "0.13", features = ["json", "rustls"], default-features = 
 
 # Misc
 glob = { version = "0.3", default-features = false }
-sysinfo = "0.38"
+sysinfo = "0.39"
 sha2 = "0.11"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 rand = "0.9"

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -85,7 +85,7 @@ serde_yaml = { version = "0.9", default-features = false }
 chrono = { version = "0.4", features = ["serde"], default-features = false }
 uuid = { version = "1.22", features = ["v4", "v5", "serde"] }
 parking_lot = "0.12"
-dashmap = "6.1"
+dashmap = "6.2"
 once_cell = "1.20"
 arc-swap = "1.7"
 lazy_static = "1.4"

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -27,7 +27,7 @@ vectorizer = { path = "../vectorizer", default-features = false }
 # HTTP / WebSocket server
 axum = { version = "0.8.7", features = ["ws", "json", "multipart"], default-features = false }
 tower = { version = "0.5", default-features = false }
-tower-http = { version = "0.6.7", features = ["cors", "trace", "fs", "set-header"], default-features = false }
+tower-http = { version = "0.6.11", features = ["cors", "trace", "fs", "set-header"], default-features = false }
 hyper = { version = "1.8.1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1.20", features = ["tokio", "server", "server-auto"] }
 

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -47,7 +47,7 @@ async-graphql = { version = "7.0", features = ["chrono", "uuid"] }
 async-graphql-axum = "7.0"
 
 # Auth + security primitives
-jsonwebtoken = { version = "10.1", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 hmac = "0.13"
 base64 = "0.22"
 bcrypt = "0.19"

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["database", "science"]
 # 0.10 or 0.11 ships, bump both pins together and retest the HA path
 # (tests/integration/cluster_ha.rs). Risk note published in CHANGELOG.
 openraft = { version = "=0.10.0-alpha.20", features = ["serde", "type-alias"] }
-openraft-memstore = "=0.10.0-alpha.18"
+openraft-memstore = "=0.10.0-alpha.20"
 futures = "0.3"
 ctrlc = { version = "3.5", optional = true }
 dirs = "6.0"

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -114,7 +114,7 @@ regex = { version = "1.10", default-features = false, features = ["std", "unicod
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 # Authentication and security
-jsonwebtoken = { version = "10.1", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 uuid = { version = "1.22", features = ["v4", "v5", "serde"] }
 rand = "0.9"
 hmac = "0.13"           # HMAC for request signing

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -65,7 +65,7 @@ num_cpus = "1.16"
 memory-stats = "1.0"
 
 # Data structures
-dashmap = "6.1"
+dashmap = "6.2"
 parking_lot = "0.12"
 once_cell = "1.20"
 arc-swap = "1.7"

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -26,7 +26,7 @@ dirs = "6.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "net", "io-util", "time", "signal", "sync", "macros"], default-features = false }
 axum = { version = "0.8.7", features = ["ws", "json", "multipart"], default-features = false }
 tower = { version = "0.5", default-features = false }
-tower-http = { version = "0.6.7", features = ["cors", "trace", "fs", "set-header"], default-features = false }
+tower-http = { version = "0.6.11", features = ["cors", "trace", "fs", "set-header"], default-features = false }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = { version = "1.0", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = "0.11"
 walkdir = "2.5"
 notify = "8.2"
 fastrand = "2.3"
-sysinfo = "0.38"
+sysinfo = "0.39"
 
 # Index and vector operations
 hnsw_rs = "0.3"


### PR DESCRIPTION
## Summary

Batch merge of 10 dependabot updates. All individually CI-green before merge into branch.

## Bumps

- jsonwebtoken 10.3.0 → 10.4.0 (#284)
- sysinfo 0.38.4 → 0.39.2 (#285)
- parquet 58.2.0 → 58.3.0 (#286)
- dashmap 6.1.0 → 6.2.1 (#287)
- openssl 0.10.79 → 0.10.80 (#288)
- bcrypt 0.19.0 → 0.19.1 (#289)
- tonic-prost-build 0.14.5 → 0.14.6 (#290)
- openraft-memstore 0.10.0-alpha.18 → 0.10.0-alpha.20 (#291)
- tower-http 0.6.8 → 0.6.11 (#292)
- lz4_flex 0.13.0 → 0.13.1 (#293)

## Test plan

- [ ] CI green on `deps/batch-2026-05` (cargo check, lint, all-features tests, rust-tests ubuntu/windows, rustdoc)
- [ ] No new clippy warnings
- [ ] Workspace builds clean against bumped versions