### PR TITLE
deps: batch dependency updates (2026-06-13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5262,9 +5262,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.20"
+version = "0.10.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a7b7775774f72c1ec9c4a7a74ec5274515c66c0af40b0f8119ebd36ec3fde4"
+checksum = "f40148cf75ead81993d5910bc72275e542e4e01a90241bf1905236843fe3009d"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -5291,9 +5291,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.20"
+version = "0.10.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880853cd85c2dd7883122134abcc5483005dd175d6027e9e00c1eede8fd2a956"
+checksum = "2ec23cd291c763fb17d8dabf7cc4eacaefd45d02e52a4df88ce50c702f030689"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -5319,9 +5319,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.20"
+version = "0.10.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba87cea8e45601807f2537fd9e657e02c9ee2fdaa9be4ece013b296b03b2c97"
+checksum = "a31c2d12e376df204612bb2016d652ea2d48b8edeaa04263facbe2fc7a11e3ef"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -5332,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.20"
+version = "0.10.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a539ef5ef89d4da720c56300aeb702d6ddf2a9fa653b029b79d30e5f8cf68fa"
+checksum = "6d8c01f2a456a864282bc4eaf76f1f78ab040d80416fd30fd15b8ab88faa337a"
 dependencies = [
  "futures-util",
  "openraft-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6235,9 +6235,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6266,9 +6266,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6279,9 +6279,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5482,9 +5482,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3613,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9320,9 +9320,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2338,7 +2338,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2624,7 +2624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4980,7 +4980,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5432,7 +5432,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry 0.32.0",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -5447,7 +5447,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -6969,9 +6969,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7264,7 +7264,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7332,7 +7332,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7842,7 +7842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8281,7 +8281,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8302,7 +8302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9445,7 +9445,7 @@ dependencies = [
  "rayon",
  "rcgen",
  "regex",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rmcp",
  "rmp-serde",
  "rrf",
@@ -9504,7 +9504,7 @@ dependencies = [
  "ctrlc",
  "libc",
  "rand 0.9.4",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_yaml",
  "sys-info",
@@ -9571,7 +9571,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "parking_lot",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -9640,7 +9640,7 @@ dependencies = [
  "rand 0.9.4",
  "rcgen",
  "regex",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rmcp",
  "rmp-serde",
  "rust-embed",
@@ -9960,7 +9960,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,9 +2710,9 @@ checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastembed"
-version = "5.13.4"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0112bd54a5d1903b19c85609c282949523bb8bb39f1614d4db0017e0ef3b0ff"
+checksum = "add59222e7bc3787285f993744b244cd454d78571845623606bdc45b22b23a4e"
 dependencies = [
  "anyhow",
  "hf-hub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7074,9 +7074,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7105,9 +7105,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/crates/vectorizer-core/Cargo.toml
+++ b/crates/vectorizer-core/Cargo.toml
@@ -49,7 +49,7 @@ tracing = { version = "0.1", default-features = false }
 # rule forces them to sit alongside `VectorizerError`.
 axum = { version = "0.8.7", default-features = false }
 tonic = { version = "0.14", features = [] }
-rmcp = { version = "1.5", features = ["server"] }
+rmcp = { version = "1.7", features = ["server"] }
 
 # Optional: gates the `CandleError` enum variant in error/
 candle-core = { version = "0.10.2", optional = true }

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -83,7 +83,7 @@ serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = { version = "1.0", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }
 chrono = { version = "0.4", features = ["serde"], default-features = false }
-uuid = { version = "1.22", features = ["v4", "v5", "serde"] }
+uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 parking_lot = "0.12"
 dashmap = "6.2"
 once_cell = "1.20"

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -28,7 +28,7 @@ vectorizer = { path = "../vectorizer", default-features = false }
 axum = { version = "0.8.7", features = ["ws", "json", "multipart"], default-features = false }
 tower = { version = "0.5", default-features = false }
 tower-http = { version = "0.6.11", features = ["cors", "trace", "fs", "set-header"], default-features = false }
-hyper = { version = "1.8.1", features = ["server", "http1", "http2"] }
+hyper = { version = "1.10.1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1.20", features = ["tokio", "server", "server-auto"] }
 
 # gRPC

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -38,7 +38,7 @@ prost = "0.14"
 prost-types = "0.14"
 
 # MCP SDK
-rmcp = { version = "1.5", features = ["server", "macros", "transport-streamable-http-server"] }
+rmcp = { version = "1.7", features = ["server", "macros", "transport-streamable-http-server"] }
 tokio-tungstenite = "0.29"
 tokio-stream = { version = "0.1", features = ["sync"] }
 

--- a/crates/vectorizer-server/Cargo.toml
+++ b/crates/vectorizer-server/Cargo.toml
@@ -134,7 +134,7 @@ flate2 = "1.1"
 tantivy = "0.26"
 
 # Openraft (replication)
-openraft = { version = "=0.10.0-alpha.20", features = ["serde", "type-alias"] }
+openraft = { version = "=0.10.0-alpha.21", features = ["serde", "type-alias"] }
 openraft-memstore = "=0.10.0-alpha.20"
 
 # Prometheus / OTel

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -157,7 +157,7 @@ arrow = { version = "58", optional = true }
 parquet = { version = "58", optional = true }
 
 # MCP SDK
-rmcp = { version = "1.5", features = ["server", "macros", "transport-streamable-http-server"] }
+rmcp = { version = "1.7", features = ["server", "macros", "transport-streamable-http-server"] }
 tokio-util = "0.7"
 async-trait = "0.1"
 lru = "0.18"

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -161,7 +161,7 @@ rmcp = { version = "1.5", features = ["server", "macros", "transport-streamable-
 tokio-util = "0.7"
 async-trait = "0.1"
 lru = "0.18"
-hyper = { version = "1.8.1", features = ["server", "http1", "http2"] }
+hyper = { version = "1.10.1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1.20", features = ["tokio", "server", "server-auto"] }
 
 # GraphQL API

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["database", "science"]
 # layer to a newer alpha whose behavior we haven't vetted. When a stable
 # 0.10 or 0.11 ships, bump both pins together and retest the HA path
 # (tests/integration/cluster_ha.rs). Risk note published in CHANGELOG.
-openraft = { version = "=0.10.0-alpha.20", features = ["serde", "type-alias"] }
+openraft = { version = "=0.10.0-alpha.21", features = ["serde", "type-alias"] }
 openraft-memstore = "=0.10.0-alpha.20"
 futures = "0.3"
 ctrlc = { version = "3.5", optional = true }

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -47,7 +47,7 @@ hnsw_rs = "0.3"
 # Intelligent search dependencies
 tantivy = "0.26"  # BM25 full-text search engine
 rrf = "0.1"       # Reciprocal Rank Fusion
-fastembed = { version = "5.13", optional = true } # Embeddings + cross-encoder reranking (requires ONNX Runtime)
+fastembed = { version = "5.16", optional = true } # Embeddings + cross-encoder reranking (requires ONNX Runtime)
 rust-tfidf = "1.1" # TF-IDF similarity fallback
 
 # Linear algebra for basic matrix operations

--- a/crates/vectorizer/Cargo.toml
+++ b/crates/vectorizer/Cargo.toml
@@ -115,7 +115,7 @@ openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 # Authentication and security
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
-uuid = { version = "1.22", features = ["v4", "v5", "serde"] }
+uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 rand = "0.9"
 hmac = "0.13"           # HMAC for request signing
 base64 = "0.22"         # Base64 encoding for signing secrets

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -39,7 +39,7 @@ path = "examples/apikey_smoke.rs"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.52", features = ["full"] }
-uuid = { version = "1.6", features = ["v4", "serde"] }
+uuid = { version = "1.23", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 anyhow = { version = "1.0", features = ["backtrace"] }
 tracing = "0.1"


### PR DESCRIPTION
## Summary

Batch merge of 10 dependabot updates. All individually CI-green before merge into branch.

## Bumps

- reqwest 0.13.3 → 0.13.4 (#309)
- uuid 1.23.1 → 1.23.2 (#310)
- prost 0.14.3 → 0.14.4 (#311)
- hyper 1.9.0 → 1.10.1 (#312)
- prost-types 0.14.3 → 0.14.4 (#313)
- openraft 0.10.0-alpha.20 → 0.10.0-alpha.21 (#314)
- chrono 0.4.44 → 0.4.45 (#315)
- fastembed 5.13.4 → 5.16.0 (#316)
- opentelemetry_sdk 0.32.0 → 0.32.1 (#317)
- rmcp 1.6.0 → 1.7.0 (#318)

## Test plan

- [ ] CI green on \`deps/batch-2026-06-13\` (cargo check, lint, all-features tests, rust-tests ubuntu/windows, rustdoc)
- [ ] No new clippy warnings
- [ ] Workspace builds clean against bumped versions